### PR TITLE
Port to Evolution 3.58 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@
 # Debug files
 *.dSYM/
 *.su
+
+# Build directories
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 # Evolution composer-rtl module build script
 
-cmake_minimum_required(VERSION 2.8)
-cmake_policy(VERSION 2.6)
+cmake_minimum_required(VERSION 3.10)
 
 project(module-composer-rtl C)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,7 +25,5 @@ target_link_libraries(module-composer-rtl
 )
 
 install(TARGETS module-composer-rtl
-	DESTINATION ${EVOLUTION_MODULE_DIR}
+	LIBRARY DESTINATION ${EVOLUTION_MODULE_DIR}
 )
-
-include_directories(/home/mehdi/src/gnome/evolution/src/modules/webkit-editor/)

--- a/src/m-msg-composer-extension.c
+++ b/src/m-msg-composer-extension.c
@@ -20,8 +20,11 @@
 
 #include <glib/gi18n-lib.h>
 #include <gtk/gtk.h>
+#include <webkit2/webkit2.h>
 
+#include <e-util/e-util.h>
 #include <composer/e-msg-composer.h>
+
 #include "m-msg-composer-extension.h"
 
 struct _MMsgComposerExtensionPrivate {
@@ -30,134 +33,109 @@ struct _MMsgComposerExtensionPrivate {
 
 G_DEFINE_DYNAMIC_TYPE (MMsgComposerExtension, m_msg_composer_extension, E_TYPE_EXTENSION)
 
-static guint64
-current_page_id (EWebKitEditor *wk_editor)
+static void
+set_text_direction (EContentEditor *content_editor,
+                    const gchar *dir)
 {
-	return webkit_web_view_get_page_id (WEBKIT_WEB_VIEW (wk_editor));
+	gchar *script;
+
+	script = g_strdup_printf (
+		"document.documentElement.setAttribute('dir', '%s');"
+		"document.body.style.direction = '%s';"
+		"document.body.style.unicodeBidi = 'embed';",
+		dir, dir);
+
+	webkit_web_view_evaluate_javascript (
+		WEBKIT_WEB_VIEW (content_editor),
+		script, -1, NULL, NULL, NULL, NULL, NULL);
+
+	g_free (script);
 }
 
 static void
-webkit_editor_set_element_attribute (EWebKitEditor *wk_editor,
-                                     const gchar *selector,
-                                     const gchar *attribute,
-                                     const gchar *value)
+action_msg_composer_ltr (EUIAction *action,
+                         GVariant *value,
+                         gpointer user_data)
 {
-	GDBusProxy *web_extension;
-	g_object_get (wk_editor, "web-extension", &web_extension, NULL);
-
-	if (!web_extension) {
-		g_warning ("EHTMLEditorWebExtension not ready at %s!", G_STRFUNC);
-		return;
-	}
-
-	e_util_invoke_g_dbus_proxy_call_with_error_check (
-		web_extension,
-		"ElementSetAttributeBySelector",
-		g_variant_new (
-			"(tsss)", current_page_id (wk_editor), selector, attribute, value),
-		NULL);
-}
-
-static void
-action_msg_composer_set_text_direction (GtkAction *action,
-							            MMsgComposerExtension *msg_composer_ext,
-								    	const gchar *dir)
-{
+	MMsgComposerExtension *ext = user_data;
 	EMsgComposer *composer;
 	EHTMLEditor *html_editor;
 	EContentEditor *content_editor;
 
-	g_return_if_fail (M_IS_MSG_COMPOSER_EXTENSION (msg_composer_ext));
+	g_return_if_fail (M_IS_MSG_COMPOSER_EXTENSION (ext));
 
-	composer = E_MSG_COMPOSER (e_extension_get_extensible (E_EXTENSION (msg_composer_ext)));
+	composer = E_MSG_COMPOSER (e_extension_get_extensible (E_EXTENSION (ext)));
 	html_editor = e_msg_composer_get_editor (composer);
 	content_editor = e_html_editor_get_content_editor (html_editor);
 
-	if (g_strcmp0 (G_OBJECT_TYPE_NAME (content_editor), "EWebKitEditor") != 0) {
-		g_warning ("EWebKitEditor not found. RTL module only works with EWebKitEditor.");
-		return;
-	}
-
-	webkit_editor_set_element_attribute((EWebKitEditor*)content_editor, "html", "dir", dir);
-	char style[33];
-	sprintf(style, "direction:%s;unicode-bidi:embed;", dir);
-
-	webkit_editor_set_element_attribute((EWebKitEditor*)content_editor,
-									    "body",
-									    "style",
-									    style);	
-}
-
-
-static void
-action_msg_composer_ltr (GtkAction *action,
-						 MMsgComposerExtension *msg_composer_ext)
-{
-	action_msg_composer_set_text_direction(action,
-										   msg_composer_ext,
-										   "ltr");
+	set_text_direction (content_editor, "ltr");
 }
 
 static void
-action_msg_composer_rtl (GtkAction *action,
-						 MMsgComposerExtension *msg_composer_ext)
+action_msg_composer_rtl (EUIAction *action,
+                         GVariant *value,
+                         gpointer user_data)
 {
-	action_msg_composer_set_text_direction(action,
-										   msg_composer_ext,
-										   "rtl");
+	MMsgComposerExtension *ext = user_data;
+	EMsgComposer *composer;
+	EHTMLEditor *html_editor;
+	EContentEditor *content_editor;
+
+	g_return_if_fail (M_IS_MSG_COMPOSER_EXTENSION (ext));
+
+	composer = E_MSG_COMPOSER (e_extension_get_extensible (E_EXTENSION (ext)));
+	html_editor = e_msg_composer_get_editor (composer);
+	content_editor = e_html_editor_get_content_editor (html_editor);
+
+	set_text_direction (content_editor, "rtl");
 }
 
-static GtkActionEntry msg_composer_entries[] = {
+static const EUIActionEntry msg_composer_entries[] = {
 	{ "ltr-composer-action",
 	  "format-text-direction-ltr",
 	  N_("Left_to_right"),
 	  NULL,
 	  N_("Left to right"),
-	  G_CALLBACK (action_msg_composer_ltr) },
+	  action_msg_composer_ltr,
+	  NULL, NULL, NULL },
 	{ "rtl-composer-action",
 	  "format-text-direction-rtl",
 	  N_("Right_to_left"),
 	  NULL,
 	  N_("Right to left"),
-	  G_CALLBACK (action_msg_composer_rtl) }
-
+	  action_msg_composer_rtl,
+	  NULL, NULL, NULL }
 };
+
+static const gchar *eui_def =
+	"<eui>"
+	"  <toolbar id='html-toolbar'>"
+	"    <item action='ltr-composer-action'/>"
+	"    <item action='rtl-composer-action'/>"
+	"  </toolbar>"
+	"</eui>";
 
 static void
 m_msg_composer_extension_add_ui (MMsgComposerExtension *msg_composer_ext,
-				 EMsgComposer *composer)
+                                 EMsgComposer *composer)
 {
-	const gchar *ui_def =
-		"<toolbar name='html-toolbar'>\n"
-		"  <toolitem action='ltr-composer-action'/>\n"
-		"  <toolitem action='rtl-composer-action'/>\n"
-		"</toolbar>\n";
-
 	EHTMLEditor *html_editor;
-	GtkActionGroup *action_group;
-	GtkUIManager *ui_manager;
-	GError *error = NULL;
+	EUIManager *ui_manager;
 
 	g_return_if_fail (M_IS_MSG_COMPOSER_EXTENSION (msg_composer_ext));
 	g_return_if_fail (E_IS_MSG_COMPOSER (composer));
 
 	html_editor = e_msg_composer_get_editor (composer);
 	ui_manager = e_html_editor_get_ui_manager (html_editor);
-	action_group = e_html_editor_get_action_group (html_editor, "html");
 
-	/* Add actions to the action group. */
-	e_action_group_add_actions_localized (
-		action_group, GETTEXT_PACKAGE,
-		msg_composer_entries, G_N_ELEMENTS (msg_composer_entries), msg_composer_ext);
-
-	gtk_ui_manager_add_ui_from_string (ui_manager, ui_def, -1, &error);
-
-	if (error) {
-		g_warning ("%s: Failed to add ui definition: %s", G_STRFUNC, error->message);
-		g_error_free (error);
-	}
-
-	gtk_ui_manager_ensure_update (ui_manager);
+	e_ui_manager_add_actions_with_eui_data (
+		ui_manager,
+		"composer-rtl",
+		GETTEXT_PACKAGE,
+		msg_composer_entries,
+		G_N_ELEMENTS (msg_composer_entries),
+		msg_composer_ext,
+		eui_def);
 }
 
 static void
@@ -172,9 +150,9 @@ m_msg_composer_extension_constructed (GObject *object)
 	/* Chain up to parent's constructed() method. */
 	G_OBJECT_CLASS (m_msg_composer_extension_parent_class)->constructed (object);
 
-	//g_print ("Hello world from %s!\n", G_OBJECT_TYPE_NAME (extensible));
-
-	m_msg_composer_extension_add_ui (M_MSG_COMPOSER_EXTENSION (object), E_MSG_COMPOSER (extensible));
+	m_msg_composer_extension_add_ui (
+		M_MSG_COMPOSER_EXTENSION (object),
+		E_MSG_COMPOSER (extensible));
 }
 
 static void
@@ -201,7 +179,10 @@ m_msg_composer_extension_class_finalize (MMsgComposerExtensionClass *class)
 static void
 m_msg_composer_extension_init (MMsgComposerExtension *msg_composer_ext)
 {
-	msg_composer_ext->priv = G_TYPE_INSTANCE_GET_PRIVATE (msg_composer_ext, M_TYPE_MSG_COMPOSER_EXTENSION, MMsgComposerExtensionPrivate);
+	msg_composer_ext->priv = G_TYPE_INSTANCE_GET_PRIVATE (
+		msg_composer_ext,
+		M_TYPE_MSG_COMPOSER_EXTENSION,
+		MMsgComposerExtensionPrivate);
 }
 
 void

--- a/src/m-msg-composer-extension.h
+++ b/src/m-msg-composer-extension.h
@@ -21,8 +21,6 @@
 #include <libebackend/libebackend.h>
 #include <gtk/gtk.h>
 
-#include "e-webkit-editor.h"
-
 /* Standard GObject macros */
 #define M_TYPE_MSG_COMPOSER_EXTENSION \
 	(m_msg_composer_extension_get_type ())
@@ -60,8 +58,8 @@ struct _MMsgComposerExtensionClass
 	EExtensionClass parent;
 };
 
-GType	m_msg_composer_extension_get_type	(void);
-void	m_msg_composer_extension_type_register	(GTypeModule *type_module);
+GType m_msg_composer_extension_get_type (void);
+void m_msg_composer_extension_type_register (GTypeModule *type_module);
 
 G_END_DECLS
 


### PR DESCRIPTION
## Summary

This PR ports the evolution-composer-rtl plugin from the Evolution 3.21 API to the current Evolution 3.58 API.

## Changes

- **Replace EWebKitEditor with EContentEditor interface** - The internal EWebKitEditor header is no longer part of the public API. All editor interactions now use the EContentEditor interface.
- **Replace GtkAction/GtkUIManager with EUIActionEntry/EUIManager** - Evolution has migrated from the deprecated GTK3 action system to its own EUI framework. Toolbar entries are now defined using .eui XML format.
- **Replace D-Bus proxy web extension calls with JavaScript evaluation** - Instead of calling through a D-Bus proxy to the web extension, text direction is now set directly via webkit_web_view_evaluate_javascript().
- **Update webkit includes** - Changed webkit/webkit.h to webkit2/webkit2.h for webkit2gtk-4.1.
- **Update CMake requirements** - Bumped cmake_minimum_required to 3.10, removed obsolete policy settings.
- **Add build/ to .gitignore** - Prevents build artifacts from being tracked.

## Testing

The plugin compiles, loads, and functions correctly with Evolution 3.58.3 on Fedora. RTL/LTR direction buttons appear in the HTML composer toolbar and correctly change text direction.